### PR TITLE
[#4] Correct Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
+sudo: false
+dist: xenial
 language: python
-python: 3.7
-  dist: xenial
-  sudo: true
+python:
+  - "2.7"
+  - "3.6"
+  - "3.7"
 install:
-  - pip install tox
-script: tox -p all
+  - pip install tox-travis
+script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,13 @@ commands = {posargs:py.test \
 addopts = --pep8 --cov-report xml
 norecursedirs = bin lib include
 
+[travis]
+python =
+  2.7: py27
+  3.6: py36
+  3.7: py37, pylint, docs
+
+
 [testenv:pylint]
 basepython = python3.7
 deps =


### PR DESCRIPTION
Use tox-travis plugin for running tox environments as pyenv does not
work with plain tox.